### PR TITLE
Add argument to skip frames at the beginning of trajectories. 

### DIFF
--- a/contact_calc/compute_contacts.py
+++ b/contact_calc/compute_contacts.py
@@ -256,7 +256,7 @@ def compute_fragment_contacts_helper(args):
 #     return stitched_filename
 
 
-def compute_contacts(top, traj, output, itypes, geom_criterion_values, cores, stride, solvent_resn, sele_id, ligand):
+def compute_contacts(top, traj, output, itypes, geom_criterion_values, cores, stride, skip, solvent_resn, sele_id, ligand):
     """ Computes non-covalent contacts across the entire trajectory and writes them to `output`.
 
     Parameters
@@ -275,6 +275,8 @@ def compute_contacts(top, traj, output, itypes, geom_criterion_values, cores, st
         Number of CPU cores to parallelize over
     stride: int, default = 1
         Frequency to skip frames in trajectory
+    skip: int, default = 0
+        Number of frames to skip at the beginning of the trajectory (to allow equilibriation)
     solvent_resn: string, default = TIP3
         Denotes the resname of solvent in simulation
     sele_id: string, default = None
@@ -297,8 +299,9 @@ def compute_contacts(top, traj, output, itypes, geom_criterion_values, cores, st
     input_args = []
 
     # Generate input arguments for each trajectory piece
-    print("Processing %s with %s total frames and stride %s" % (traj, str(sim_length), str(stride)))
-    for frag_idx, beg_frame in enumerate(range(0, sim_length, TRAJ_FRAG_SIZE)):
+    print("Processing %s with %s total frames and stride %s, skipping first %s frames"
+          % (traj, str(sim_length), str(stride), str(skip)))
+    for frag_idx, beg_frame in enumerate(range(skip, sim_length, TRAJ_FRAG_SIZE)):
         # if frag_idx > 0: break
         end_frame = beg_frame + TRAJ_FRAG_SIZE - 1
         # print("Preparing fragment %s, beg_frame:%s end_frame:%s" % (frag_idx, beg_frame, end_frame))

--- a/get_dynamic_contacts.py
+++ b/get_dynamic_contacts.py
@@ -66,7 +66,7 @@ optional arguments:
     --sele SELECTION        atom selection query in VMD [default = None]
     --ligand LIGAND         resname of ligand molecule [default = None]
     --stride STRIDE         skip frames with specified frequency [default = 1]
-    --skip SKIP             skip specified number of frames at beggining of trajectory [default = 0]
+    --skip SKIP             skip specified number of frames at beginning of trajectory [default = 0]
 
 geometric criteria options:
     --sb_cutoff_dist SALT_BRIDGE_CUTOFF_DISTANCE
@@ -190,7 +190,7 @@ def main(traj_required=True):
     parser.add_argument('--solv', type=str, default="TIP3", help='resname of solvent molecule')
     parser.add_argument('--sele', type=str, default=None, help='atom selection query in VMD')
     parser.add_argument('--stride', type=int, default=1, help='skip frames with specified frequency')
-    parser.add_argument('--skip', type=int, default=0, help='skip specified number of frames at beggining of trajectory')
+    parser.add_argument('--skip', type=int, default=0, help='skip specified number of frames at beginning of trajectory')
     parser.add_argument('--ligand', type=str, nargs="+", default=[], help='resname of ligand molecule')
 
     # Parse geometric criterion arguments

--- a/get_dynamic_contacts.py
+++ b/get_dynamic_contacts.py
@@ -65,6 +65,8 @@ optional arguments:
     --solv SOLVENT          resname of solvent molecule [default = "TIP3"]
     --sele SELECTION        atom selection query in VMD [default = None]
     --ligand LIGAND         resname of ligand molecule [default = None]
+    --stride STRIDE         skip frames with specified frequency [default = 1]
+    --skip SKIP             skip specified number of frames at beggining of trajectory [default = 0]
 
 geometric criteria options:
     --sb_cutoff_dist SALT_BRIDGE_CUTOFF_DISTANCE
@@ -188,6 +190,7 @@ def main(traj_required=True):
     parser.add_argument('--solv', type=str, default="TIP3", help='resname of solvent molecule')
     parser.add_argument('--sele', type=str, default=None, help='atom selection query in VMD')
     parser.add_argument('--stride', type=int, default=1, help='skip frames with specified frequency')
+    parser.add_argument('--skip', type=int, default=0, help='skip specified number of frames at beggining of trajectory')
     parser.add_argument('--ligand', type=str, nargs="+", default=[], help='resname of ligand molecule')
 
     # Parse geometric criterion arguments
@@ -231,6 +234,7 @@ def main(traj_required=True):
     solv = args.solv
     sele = args.sele
     stride = args.stride
+    skip = args.skip
     geom_criterion_values = process_geometric_criterion_args(args)
 
     # Check interaction types
@@ -247,7 +251,7 @@ def main(traj_required=True):
 
     # Begin computation
     tic = datetime.datetime.now()
-    compute_contacts(top, traj, output, itypes, geom_criterion_values, cores, stride, solv, sele, ligand)
+    compute_contacts(top, traj, output, itypes, geom_criterion_values, cores, stride, skip, solv, sele, ligand)
     toc = datetime.datetime.now()
     print("Computation time: " + str((toc-tic).total_seconds()) + " seconds")
 


### PR DESCRIPTION
When I use this tool, I generally have to make a copy of my trajectory with the first few hundred ns removed (to allow for the system to equilibrate before computing statistics). Adding this option to skip a specified number of frames would make this simpler.