### PR TITLE
Avoid disulphide bridges when computing VdW or Hb

### DIFF
--- a/contact_calc/contact_utils.py
+++ b/contact_calc/contact_utils.py
@@ -388,6 +388,18 @@ def calc_water_to_residues_map(water_hbonds, solvent_resn):
 
     return frame_idx, water_to_residues, solvent_bridges
 
+def find_disulfide(top, traj):
+    """
+    Find Cysteines making disulfide bridges and return their resids
+    """
+    molid = load_traj(top, traj, 0, 1, 1)
+    evaltcl("set bridge_cys [atomselect %s \" resname CYS  \" frame 0]" % molid)
+    cys_all = set(evaltcl("$bridge_cys get resid").split())
+    evaltcl("set bridge_cys [atomselect %s \" name HG1 and resname CYS  \" frame 0]" % molid)
+    cys_nobridge = set(evaltcl("$bridge_cys get resid").split())
+    cys_bridge = cys_all.difference(cys_nobridge)
+    cys_bridge =  set(map(int, cys_bridge))
+    return(cys_bridge)
 
 def configure_solv(top, traj, solvent_sele):
     """

--- a/contact_calc/contact_utils.py
+++ b/contact_calc/contact_utils.py
@@ -392,14 +392,16 @@ def find_disulfide(top, traj):
     """
     Find Cysteines making disulfide bridges and return their resids
     """
+    disulfide_pairs = list()
     molid = load_traj(top, traj, 0, 1, 1)
-    evaltcl("set bridge_cys [atomselect %s \" resname CYS  \" frame 0]" % molid)
-    cys_all = set(evaltcl("$bridge_cys get resid").split())
-    evaltcl("set bridge_cys [atomselect %s \" name HG1 and resname CYS  \" frame 0]" % molid)
-    cys_nobridge = set(evaltcl("$bridge_cys get resid").split())
-    cys_bridge = cys_all.difference(cys_nobridge)
-    cys_bridge =  set(map(int, cys_bridge))
-    return(cys_bridge)
+    evaltcl("set cys_all [atomselect %s \" resname CYS  \" frame 0]" % molid)
+    cys_all = set(evaltcl("$cys_all get resid").split())
+    for cys in cys_all:
+        evaltcl("set bridge_cys [atomselect %s \" name SG and within 2.1 of (resid %s and name SG)  \" frame 0]" % (molid, cys))
+        disulfide_pair = set(map(int,evaltcl("$bridge_cys get resid").split()))
+        if len(disulfide_pair) == 2 and disulfide_pair not in disulfide_pairs:
+            disulfide_pairs.append(disulfide_pair)
+    return(disulfide_pairs)
 
 def configure_solv(top, traj, solvent_sele):
     """

--- a/contact_calc/hydrophobics.py
+++ b/contact_calc/hydrophobics.py
@@ -99,7 +99,7 @@ def compute_hydrophobics(traj_frag_molid, frame_idx, index_to_atom, sele1, sele2
             continue
 
         #Check and continue if disulphide bond
-        if atom1.resname == atom2.resname == "CYS" and atom1.name == atom2.name == "SG":
+        if atom1.resid in disulfide_cys and atom2.resid in disulfide_cys:
             continue
 
         # Perform distance cutoff with atom indices

--- a/contact_calc/hydrophobics.py
+++ b/contact_calc/hydrophobics.py
@@ -99,8 +99,9 @@ def compute_hydrophobics(traj_frag_molid, frame_idx, index_to_atom, sele1, sele2
             continue
 
         #Check and continue if disulphide bond
-        if atom1.resid in disulfide_cys and atom2.resid in disulfide_cys:
-            continue
+        if atom1.resname == atom2.resname == "CYS":
+            if set((atom1.resid, atom2.resid)) in disulfide_cys:
+                continue
 
         # Perform distance cutoff with atom indices
         distance = compute_distance(traj_frag_molid, frame_idx, atom1_index, atom2_index)

--- a/contact_calc/hydrophobics.py
+++ b/contact_calc/hydrophobics.py
@@ -98,6 +98,10 @@ def compute_hydrophobics(traj_frag_molid, frame_idx, index_to_atom, sele1, sele2
         if atom1.chain == atom2.chain and abs(atom1.resid - atom2.resid) < res_diff:
             continue
 
+        #Check and continue if disulphide bond
+        if atom1.resname == atom2.resname == "CYS" and atom1.name == atom2.name == "SG":
+            continue
+
         # Perform distance cutoff with atom indices
         distance = compute_distance(traj_frag_molid, frame_idx, atom1_index, atom2_index)
         vanderwaal_cutoff = atom1.vdwradius + atom2.vdwradius + epsilon

--- a/contact_calc/vanderwaals.py
+++ b/contact_calc/vanderwaals.py
@@ -31,7 +31,7 @@ def update_soft_cutoff(traj_frag_molid, index_to_atom, sele1, sele2, epsilon, ge
     geom_criteria['soft_vdw_cutoff'] = max_vdw1 + max_vdw2 + epsilon
 
 
-def compute_vanderwaals(traj_frag_molid, frame, index_to_atom, sele1, sele2, geom_criteria):
+def compute_vanderwaals(traj_frag_molid, frame, index_to_atom, sele1, sele2, geom_criteria, disulfide_cys):
     """
     Compute all vanderwaals interactions in a frame of simulation
 
@@ -49,6 +49,9 @@ def compute_vanderwaals(traj_frag_molid, frame, index_to_atom, sele1, sele2, geo
         If second VMD query is specified, then compute contacts between atom selection 1 and 2
     geom_criteria: dict
         Container for geometric criteria
+    disulfide_cys: set
+        Set with residue ids of cysteines making disulfide bridges
+
 
     Returns
     -------
@@ -79,7 +82,7 @@ def compute_vanderwaals(traj_frag_molid, frame, index_to_atom, sele1, sele2, geo
             continue
 
         #Check and continue if disulphide bond
-        if atom1.resname == atom2.resname == "CYS" and atom1.name == atom2.name == "SG":
+        if atom1.resid in disulfide_cys and atom2.resid in disulfide_cys:
             continue
 
         # Perform distance cutoff with atom indices

--- a/contact_calc/vanderwaals.py
+++ b/contact_calc/vanderwaals.py
@@ -78,6 +78,10 @@ def compute_vanderwaals(traj_frag_molid, frame, index_to_atom, sele1, sele2, geo
         if atom1.chain == atom2.chain and abs(atom1.resid - atom2.resid) < res_diff:
             continue
 
+        #Check and continue if disulphide bond
+        if atom1.resname == atom2.resname == "CYS" and atom1.name == atom2.name == "SG":
+            continue
+
         # Perform distance cutoff with atom indices
         distance = compute_distance(traj_frag_molid, frame, atom1_index, atom2_index)
 

--- a/contact_calc/vanderwaals.py
+++ b/contact_calc/vanderwaals.py
@@ -82,8 +82,9 @@ def compute_vanderwaals(traj_frag_molid, frame, index_to_atom, sele1, sele2, geo
             continue
 
         #Check and continue if disulphide bond
-        if atom1.resid in disulfide_cys and atom2.resid in disulfide_cys:
-            continue
+        if atom1.resname == atom2.resname == "CYS":
+            if set((atom1.resid, atom2.resid)) in disulfide_cys:
+                continue
 
         # Perform distance cutoff with atom indices
         distance = compute_distance(traj_frag_molid, frame, atom1_index, atom2_index)


### PR DESCRIPTION
Disulfide bridges cause false high frequency Van der Waals and Hydrophobic interactions between two Cysteines. To avoid this, I propose the following changes, in which all Van der Waals and hydrophobic interactions between atoms of two cysteines forming a disulfide bridge are ignored