### PR TITLE
Added O1P and O2P as valid nucleic phosphate names

### DIFF
--- a/contact_calc/salt_bridges.py
+++ b/contact_calc/salt_bridges.py
@@ -24,7 +24,7 @@ __all__ = ['compute_salt_bridges']
 
 acidic_asp = "((resname ASP) and (name OD1 OD2))"
 acidic_glu = "((resname GLU) and (name OE1 OE2))"
-acidic_nucl = "((resname C U G A DC DT DG DA) and (name OP1 OP2))"
+acidic_nucl = "((resname C U G A DC DT DG DA) and (name OP1 OP2 O1P O2P))"
 basic_his = "((resname HIS HSD HSE HSP HIE HIP HID) and (name ND1 NE2))"
 basic_lys = "((resname LYS) and (name NZ))"
 basic_arg = "((resname ARG) and (name NH1 NH2))"


### PR DESCRIPTION
Hi, this is a very minor change, but the the force field I am using, DNA oxygen phosphates are called O1P and O2P (instead of OP1 and OP2). I've added that to `salt_bridges.py` so that salt bridges can be detected.